### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [21/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nagios.json
+++ b/chef/data_bags/crowbar/bc-template-nagios.json
@@ -10,6 +10,10 @@
   "deployment": {
     "nagios": {
       "crowbar-revision": 0,
+      "element_states": {
+        "nagios-server": [ "readying", "ready", "applying" ],
+        "nagios-client": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "nagios-server", "nagios-client" ]

--- a/chef/data_bags/crowbar/bc-template-nagios.schema
+++ b/chef/data_bags/crowbar/bc-template-nagios.schema
@@ -29,6 +29,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-nagios.json   |    4 ++++
 chef/data_bags/crowbar/bc-template-nagios.schema |   10 ++++++++++
 2 files changed, 14 insertions(+), 0 deletions(-)
