### PR TITLE
Pull changes from development into essex-hack [6/16]

### DIFF
--- a/chef/cookbooks/nagios/recipes/monitor_hw_client.rb
+++ b/chef/cookbooks/nagios/recipes/monitor_hw_client.rb
@@ -38,7 +38,8 @@ if node["roles"].include?("nagios-client")
 
   if raid_type
     # ensure raid utilities are installed, if we have raid
-    include_recipe "raid::install_tools"
+    ##include_recipe "raid::install_tools"
+    # - if raid is available, crowbar made sure to install the tools.
     execute "setuid on sas2ircu" do
       command "chmod g+rsx #{nagios_plugins}/check_sas2ircu"
     end

--- a/crowbar_framework/app/models/nagios_service.rb
+++ b/crowbar_framework/app/models/nagios_service.rb
@@ -23,13 +23,16 @@ class NagiosService < ServiceObject
   def create_proposal
     @logger.debug("Nagios create_proposal: entering")
     base = super
-    raid_bc = ProposalObject.find_proposals("raid")
-    ipmi_bc = ProposalObject.find_proposals("ipmi")
+    sc = ServiceObject.barclamp_catalog
+    enab_raid = !sc["barclamps"]["raid"].nil? rescue false
+    enab_ipmi = !sc["barclamps"]["ipmi"].nil? rescue false
+
+    ## all good and fine, but we're not officially suporting HW monitoring for now..
+    enab_raid = enab_ipmi = false
     
-    enab_raid = (!raid_bc.nil? and raid_bc.length > 0)
-    enab_ipmi = (!ipmi_bc.nil? and ipmi_bc.length > 0)
     base["attributes"]["nagios"]["monitor_raid"] = enab_raid
     base["attributes"]["nagios"]["monitor_ipmi"] = enab_ipmi
+
     @logger.debug("Nagios create_proposal: exiting. IPMI: #{enab_raid}, RAID: #{enab_ipmi}")
     base
   end


### PR DESCRIPTION
Synchronize essex-hack with development. Among other things, this
pulls in:
- Numerous UI improvements.
- Enhancements and bugfixes galore in the dev tool and build system.
- Sledgehammer on CentOS 6.2 support.
- Somewhat more standardized patch management for our Chef and Rails
  patches.

This pull request series has been smoketested on virtual machines, and
is able to spin up vms in Nova using the dashboard.

 chef/cookbooks/nagios/recipes/monitor_hw_client.rb |    3 ++-
 crowbar_framework/app/models/nagios_service.rb     |   11 +++++++----
 2 files changed, 9 insertions(+), 5 deletions(-)
