### PR TITLE
Fix EPEL meta-package version [3/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -68,12 +68,6 @@ rpms:
   redhat-5.7:
     repos:
       - bare epel5-nagios3 10 http://repos.fedorapeople.org/repos/peter/nagios3/epel-5/x86_64/
-  redhat-6.2:
-    repos:
-      - rpm http://download.fedora.redhat.com/pub/epel/6/x86_64/epel-release-6-5.noarch.rpm
-  centos-6.2:
-    repos:
-      - rpm http://download.fedora.redhat.com/pub/epel/6/x86_64/epel-release-6-5.noarch.rpm
   pkgs:
     - nagios
     - nrpe


### PR DESCRIPTION
This updates the EPEL metapackage from version 6.6 to 6.7.

This should make builds succeed again by being able to pull in kwalify.

 crowbar.yml |    6 ------
 1 file changed, 6 deletions(-)
