### PR TITLE
Remove line feeds that prevent the full status from being returned to Nagios

### DIFF
--- a/chef/cookbooks/nagios/files/default/plugins/check_sas2ircu
+++ b/chef/cookbooks/nagios/files/default/plugins/check_sas2ircu
@@ -59,7 +59,7 @@ foreach my $line (split /\n/, `$sas2ircu LIST`) {
 }
 
 unless ( scalar keys %controllers ) {
-    print "No controller found\n";
+    print "No controller found. ";
     exit ($ERRORS{'UNKNOWN'});
 }
 
@@ -125,7 +125,7 @@ foreach my $ctrl_id (keys %controllers) {
     }
 
     unless ( scalar keys %volumes_infos ) {
-        print "\tNo volume found\n";
+        print "No volume found. ";
         next;
     }
 


### PR DESCRIPTION
Only the first line gets returned.  Avoid 1/2 status messages
