### PR TITLE
re-factor out intialize method in controllers [7/22]

### DIFF
--- a/crowbar_framework/app/controllers/nagios_controller.rb
+++ b/crowbar_framework/app/controllers/nagios_controller.rb
@@ -15,8 +15,12 @@
 
 
 class NagiosController < BarclampController
-  def initialize
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = NagiosService.new logger
   end
+
+  private :set_service_object
 end
 


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/nagios_controller.rb           |   48 +++++++++++---------
 1 files changed, 26 insertions(+), 22 deletions(-)
