### PR TITLE
Rework how we allocate disks to barclamps. Will close DE1120 and DE1162. [2/8]

### DIFF
--- a/chef/cookbooks/nagios/recipes/server.rb
+++ b/chef/cookbooks/nagios/recipes/server.rb
@@ -230,7 +230,7 @@ nova_commands = %w{ check_nova_manage }
 swift_svcs = %w{swift-object swift-object-auditor swift-object-replicator swift-object-updater} 
 swift_svcs =swift_svcs + %w{swift-container swift-container-auditor swift-container-replicator swift-container-updater}
 swift_svcs =swift_svcs + %w{swift-account swift-account-reaper swift-account-auditor swift-account-replicator}
-swift_svcs =swift_svcs + ["swift-proxy"] 
+swift_svcs =swift_svcs + ["swift-proxy"]
 
 glance_svcs = %w{glance-api glance-registry}
 keystone_svcs = %w{keystone}

--- a/chef/cookbooks/nagios/templates/default/services.cfg.erb
+++ b/chef/cookbooks/nagios/templates/default/services.cfg.erb
@@ -269,7 +269,7 @@ define service {
 # check the proxy
 define service {
     service_description swift proxy process
-    hostgroup_name      swift-proxy-acct
+    hostgroup_name      swift-proxy
     check_command       check_swift-proxy
     use                 default-service
 }
@@ -321,7 +321,7 @@ define service {
 
 define service {
     service_description swift http port for proxy server
-	hostgroup_name      swift-proxy-acct
+	hostgroup_name      swift-proxy
 	check_command       check_port_swift-proxy
     use                 default-service
 }


### PR DESCRIPTION
For many releases, Crowbar has built node[:crowbar][:disks] at node
discovery time, and the Chef cookbooks have used what is in that array
to determine what drives they can use.  This scheme has a few
shortcomings:

 1 The code always assumed that /dev/sda was going to be the boot
    device.
 2 The list was built at discovery time, and so it was blind to any
    changes in the disk topology that would happen when the raid
    barclamp did its thing
 3 The only choices for a disk role were OS and Storage, leading to
    all sorts of fun when multiple roles wanted to grab a physical
    disk or twenty to get all Big Data.

To fix the above shortcomings, I have replaced node[:crowbar][:disks]
with a set of methods on the
BarclampInventory::Barclamp::Inventory::Disk class (and its objects)
that let you:

 1 Get a list of all unclaimed fixed nonremovable disks on a node.
 2 Get a list of all disks that have been claimed by a barclamp on a
    node.
 3 Claim a disk for a barclamp.
 4 Release a claim for a disk.

To make sure that the claims for a disk stay relatively sane, there
are some restrictions on when you can claim a disk:

 1 You cannot claim a disk before the RAID barclamp has finished
    making any changes it is going to make to a system.
 2 You can only make and release claims to a disk on the node that
    has the disk.  In practice, this means that the only place you can
    claim a disk is in a recipe running on the node that has the disks
    to be claimed or released.

How it is implemented:

All claims to a disk are tracked on
node[:crowbar_wall][:claimed_disks][disk.unique_name]
disk.unique_name is a method that looks up as unique a name as
possible for the disk, making the claim and release machinery as
insensitive to the vagaries of device naming as you can reasonably get
on a modern Linux system.

 chef/cookbooks/nagios/recipes/server.rb            |    2 +-
 .../nagios/templates/default/services.cfg.erb      |    4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: af9a80a504bf66b9f098a6eb589cb881facd40d3

Crowbar-Release: pebbles
