### PR TITLE
DE1191 -- fix warnings in Nagios logs [1/2]

### DIFF
--- a/chef/cookbooks/nagios/templates/default/services.cfg.erb
+++ b/chef/cookbooks/nagios/templates/default/services.cfg.erb
@@ -226,12 +226,16 @@ define service {
 #    check_command       check_nova_network
 #    use                 default-service
 #}
-define service {
-    service_description Multi Nova System
-    hostgroup_name      nova-multi-controller
-    check_command       check_nova_manage
-    use                 default-service
-}
+#
+# Commenting out check_nova_manage as nova-manage command now relies
+# on keystone for authenication -- will revisit in Mesa 1.7
+#
+#define service {
+#    service_description Multi Nova System
+#    hostgroup_name      nova-multi-controller
+#    check_command       check_nova_manage
+#    use                 default-service
+#}
 #define service {
 #    service_description Multi Nova Mysql
 #    hostgroup_name      nova-multi-controller


### PR DESCRIPTION
Multi-nova-controller uses manage-nova command to monitor services. This
command relies on keystone for authenication.  The recipes for nova/nagios
will need to be updated to reflect these changes.  Since this is classified
as qa minor bug recommend pushing to mesa 1.7.

 .../nagios/templates/default/services.cfg.erb      |   28 +++++++++++---------
 1 file changed, 16 insertions(+), 12 deletions(-)

Crowbar-Pull-ID: 3db71170069a0d35fc2ebfd49f6acb971c481dc7

Crowbar-Release: mesa-1.6
