### PR TITLE
Windows Server 2012 / Hyper-V Server 2012 support [1/9]

### DIFF
--- a/chef/cookbooks/nagios/recipes/client.rb
+++ b/chef/cookbooks/nagios/recipes/client.rb
@@ -56,7 +56,9 @@ search(:node, "roles:nagios-server#{env_filter}") do |n|
   end
 end
 
-include_recipe "nagios::common"
+unless node[:platform] == "windows"
+  include_recipe "nagios::common"
+end
 
 # Package/plugin install list
 case node[:platform]
@@ -74,26 +76,28 @@ when "suse"
   lib64 = "64"
 end
 
-#save for other recipes that might contribute plugins.
-node.set["nagios"]["plugin_dir"] = plugin_dir
+unless node[:platform] == "windows"
+  #save for other recipes that might contribute plugins.
+  node.set["nagios"]["plugin_dir"] = plugin_dir
 
-if lib64 == ""
-  bash "Fix nrpe startup script" do
-    code <<-'EOH'
+  if lib64 == ""
+    bash "Fix nrpe startup script" do
+      code <<-'EOH'
 killall nrpe
 sed -ie "s/\(.*start_daemon.*\)/\1\n\tpidof nrpe > \$PIDDIR\/nrpe.pid/g" /etc/init.d/nagios-nrpe-server
 EOH
-    not_if "grep -q pidof /etc/init.d/nagios-nrpe-server"
+      not_if "grep -q pidof /etc/init.d/nagios-nrpe-server"
+    end
   end
-end
 
-# Set directory ownership and permissions
-remote_directory plugin_dir do
-  source "plugins"
-  owner "nagios"
-  group "nagios"
-  mode 0755
-  files_mode 0755
+  # Set directory ownership and permissions
+  remote_directory plugin_dir do
+    source "plugins"
+    owner "nagios"
+    group "nagios"
+    mode 0755
+    files_mode 0755
+  end
 end
 
 # NTP server setup
@@ -104,48 +108,49 @@ ntp_servers = "127.0.0.1" if node[:ntp].nil? or node[:ntp][:ntp_servers].nil? or
 
 own_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 
-# common
-vars = { :lib64 => lib64, :mon_host => mon_host, :provisioner_ip => provisioner_ip, :domain_name => domain_name, :admin_interface => admin_interface, :plugin_dir => plugin_dir, :own_admin_ip => own_admin_ip}
-# ntp
-vars.merge!({:ntp_servers => ntp_servers})
- 
-template "/etc/nagios/nrpe.cfg" do
-  source "nrpe.cfg.erb"
-  owner "nagios"
-  group "nagios"
-  mode "0644"
-  variables(vars)
-  notifies :restart, "service[nagios-nrpe-server]"
-end
+unless node[:platform] == "windows"
+  # common
+  vars = { :lib64 => lib64, :mon_host => mon_host, :provisioner_ip => provisioner_ip, :domain_name => domain_name, :admin_interface => admin_interface, :plugin_dir => plugin_dir, :own_admin_ip => own_admin_ip}
+  # ntp
+  vars.merge!({:ntp_servers => ntp_servers})
 
-# Set file ownership and permissions
-file "#{plugin_dir}/check_dhcp" do
-  mode "4755"
-  owner "root"
-  group "root"
-end
+  template "/etc/nagios/nrpe.cfg" do
+    source "nrpe.cfg.erb"
+    owner "nagios"
+    group "nagios"
+    mode "0644"
+    variables(vars)
+    notifies :restart, "service[nagios-nrpe-server]"
+  end
 
-# Set file ownership and permissions
-file "#{plugin_dir}/check_apt" do
-  mode "4755"
-  owner "root"
-  group "root"
-end
+  # Set file ownership and permissions
+  file "#{plugin_dir}/check_dhcp" do
+    mode "4755"
+    owner "root"
+    group "root"
+  end
 
-# Service startup definition
-service "nagios-nrpe-server" do
-  service_name nrpe_svc_name
-  action :enable
-  supports :restart => true, :reload => true
-end
+  # Set file ownership and permissions
+  file "#{plugin_dir}/check_apt" do
+    mode "4755"
+    owner "root"
+    group "root"
+  end
 
-# Fix rabbit tests
-bash "replace parts of alertness tools" do
-  code <<-'EOH'
+  # Service startup definition
+  service "nagios-nrpe-server" do
+    service_name nrpe_svc_name
+    action :enable
+    supports :restart => true, :reload => true
+  end
+
+  # Fix rabbit tests
+  bash "replace parts of alertness tools" do
+    code <<-'EOH'
 sed -ie "s/Management: Web UI/RabbitMQ Management/g" /usr/lib/nagios/plugins/check_rabbitmq_aliveness
 exit 0
 EOH
-  action :run
+    action :run
+  end
 end
-
 

--- a/chef/cookbooks/nagios/recipes/monitor_hw_client.rb
+++ b/chef/cookbooks/nagios/recipes/monitor_hw_client.rb
@@ -17,7 +17,7 @@
 # Note : This script runs on node and installs the local plugins and NRPE
 #
 
-if node["roles"].include?("nagios-client")
+if node[:platform] != "windows" and node["roles"].include?("nagios-client")
   include_recipe "nagios::common"
   nagios_plugins =node["nagios"]["plugin_dir"]
   raid_type = node["crowbar_wall"]["raid"]["controller"] rescue nil


### PR DESCRIPTION
## Windows integration required patches in the following areas:
- Ruby 1.9 compatibility as the Windows Chef client is based on Ruby 1.9
- Provisioner barclamp updated for supporting multiple operating systems
- Provisioner barclamp updated for generating Windows unattended.xml files
- TFTP server configuration updated for Windows support
- Crowbar barclamp web UI updated for multiple operating systems support
- NTP support for Windows
- Filters for Linux specific settings on Windows
## Limitations:
- Single Windows image supported. This is due to limitations on the way Windows
  pulls components via TFTP during PXE boot. This issue can be solved in various ways
  that require additional external dependencies that need to be discussed.
- No Nagios and Ganglia clients on Windows
- No IPMI support on Windows
- Windows Administrator password is currently provided in clear text. Needs to be 
  replaced with hash generated by Windows Assesment and Deployment Kit (ADK).
## Additional requirements:
- A Windows image is required to generate the WinPE image used during PXE boot.
  For licensing reasons the image has to be generated by the user/deployer. Scripts
  to automate the instalation of the ADK and the generation of the image are available
  here: http://github.com/adk-tools
  
  chef/cookbooks/nagios/recipes/client.rb            |  107 ++++++++++----------
  chef/cookbooks/nagios/recipes/monitor_hw_client.rb |    2 +-
  2 files changed, 57 insertions(+), 52 deletions(-)

Crowbar-Pull-ID: 58a2078e8676eb14d4439f36e1ad3e1385f0a21b

Crowbar-Release: pebbles
