### PR TITLE
Replaced gitignore file with content as in all other barclamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-*.lock
-*.lck
-*.iso
-build-info
-sha1sums
-testing/
+.DS_Store
 *~
-.#*
+
+.coverage/
+rubydeps.*

--- a/gitignore
+++ b/gitignore
@@ -1,5 +1,0 @@
-.DS_Store
-*~
-
-.coverage/
-rubydeps.*


### PR DESCRIPTION
I renamed the gitignore within
https://github.com/tboerger/barclamp-nagios/commit/dd4fe83e07cac5a13dc52124ecdbd4d13d305644
wrong. Simply renamed it to .gitignore now.
